### PR TITLE
modd: use daemon for webserver, not prep

### DIFF
--- a/modd.conf
+++ b/modd.conf
@@ -1,6 +1,6 @@
 backend/*.go !backend/go.mod !**/*_test.go {
     indir: backend
-    prep: go run main.go serve
+    daemon: go run main.go serve
 }
 
 backend/go.mod {


### PR DESCRIPTION
modd expects things marked as prep to terminate, and blocks everything else on them. Daemons get run in the background and are restarted when needed.