### PR TITLE
modd: run the package not a specific file

### DIFF
--- a/modd.conf
+++ b/modd.conf
@@ -1,6 +1,6 @@
 backend/**.go !**_test.go {
     indir: backend
-    daemon: go run main.go serve
+    daemon: go run . serve
 }
 
 backend/go.mod {


### PR DESCRIPTION
Use `go run .` instead of `go run main.go` so you can have code in more than one file :)